### PR TITLE
add gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,47 @@
+image: ubuntu:18.04
+
+variables:
+  DEBIAN_FRONTEND: noninteractive
+
+before_script:
+  - apt-get -qq update > /dev/null 2>&1
+  - apt-get -qq install -y curl > /dev/null 2>&1
+  - curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  - apt-get -qq install -y nodejs autoconf automake build-essential gcc g++ make rpm > /dev/null 2>&1
+  - npm install
+
+build:
+  except:
+    - tags
+  script:
+    - npm run build
+    - npm run pack
+    - cp output/build/*.* ./
+  artifacts:
+    name: fan-control-${CI_COMMIT_REF_SLUG}
+    when: on_success
+    paths:
+      - '*.AppImage'
+      - '*.snap'
+      - '*.tar.gz'
+      - '*.deb'
+      - '*.rpm'
+
+release:
+  except:
+    - branches
+  only:
+    - tags
+  script:
+    - npm run build:prod
+    - npm run pack:prod
+    - cp output/build/*.* ./
+  artifacts:
+    name: fan-control-${CI_COMMIT_REF_SLUG}
+    when: on_success
+    paths:
+      - '*.AppImage'
+      - '*.snap'
+      - '*.tar.gz'
+      - '*.deb'
+      - '*.rpm'


### PR DESCRIPTION
Allow automatic build for anyone who runs their own Gitlab Server.

2 jobs, one for any branch, and a release job, which is triggered automatically when creating a tag within the master.

For both jobs I've chosen to copy the artifacts to the root of the project before adding them as artifacts, this way you end of with a clean artifact within Gitlab without any subfolders.

Hope you will consider this adding this.

![Screenshot from 2019-05-04 17-59-40](https://user-images.githubusercontent.com/6072255/57181614-72b31700-6e96-11e9-9ceb-526634375db9.png)
